### PR TITLE
Email invite functionality complete

### DIFF
--- a/app/controllers/invite_controller.rb
+++ b/app/controllers/invite_controller.rb
@@ -3,14 +3,14 @@ class InviteController < ApplicationController
   end
 
   def create
-    github_email = InviteFacade.new(current_user)
-    if github_email.github_lookup(params[:github_handle]) == nil
+    invite = InviteFacade.new(current_user)
+    user = invite.github_lookup(params[:github_handle])
+    if user[:email] == nil
       flash[:error] = "The Github user you selected doesn't have an email address associated with their account."
-      redirect_to '/dashboard'
     else
-    UserMailer.with(user: @user).welcome_email.deliver_now
-
+      UserMailer.invite_email(user, current_user).deliver_now
+      flash[:success] = "Successfully sent invite!"
+    end
     redirect_to '/dashboard'
-    flash[:success] = "Successfully sent invite!"
   end
 end

--- a/app/controllers/invite_controller.rb
+++ b/app/controllers/invite_controller.rb
@@ -1,0 +1,16 @@
+class InviteController < ApplicationController
+  def new
+  end
+
+  def create
+    github_email = InviteFacade.new(current_user)
+    if github_email.github_lookup(params[:github_handle]) == nil
+      flash[:error] = "The Github user you selected doesn't have an email address associated with their account."
+      redirect_to '/dashboard'
+    else
+    UserMailer.with(user: @user).welcome_email.deliver_now
+
+    redirect_to '/dashboard'
+    flash[:success] = "Successfully sent invite!"
+  end
+end

--- a/app/facades/invite_facade.rb
+++ b/app/facades/invite_facade.rb
@@ -1,0 +1,11 @@
+class InviteFacade
+
+  def initialize(current_user)
+    @current_user = current_user
+  end
+
+  def github_lookup(github_handle)
+    service = GithubService.new(@current_user)
+    email = service.find_github_user(github_handle)
+  end
+end

--- a/app/facades/invite_facade.rb
+++ b/app/facades/invite_facade.rb
@@ -6,6 +6,6 @@ class InviteFacade
 
   def github_lookup(github_handle)
     service = GithubService.new(@current_user)
-    email = service.find_github_user(github_handle)
+    service.find_github_user(github_handle)
   end
 end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -3,4 +3,10 @@ class UserMailer < ApplicationMailer
     @user = params[:user]
     mail(to: @user.email, subject: 'Welcome to Turing Tutorials!')
   end
+
+  def invite_email(user, current_user)
+    @user = user
+    @current_user_name = "#{current_user.first_name} #{current_user.last_name}"
+    mail(to: user[:email], subject: "You've been invited to Turing Tutorials!")
+  end
 end

--- a/app/services/github_service.rb
+++ b/app/services/github_service.rb
@@ -5,7 +5,7 @@ class GithubService
   end
 
   def find_github_user(github_handle)
-    response = Faraday.get "https://api.github.com/users/#{github_handle}"
+    response = conn.get("users/#{github_handle}")
     JSON.parse(response.body, symbolize_names: true)
   end
 

--- a/app/services/github_service.rb
+++ b/app/services/github_service.rb
@@ -4,6 +4,11 @@ class GithubService
     @current_user = current_user
   end
 
+  def find_github_user(github_handle)
+    response = Faraday.get "https://api.github.com/users/#{github_handle}"
+    JSON.parse(response.body, symbolize_names: true)
+  end
+
   def fetch_repos
     response = conn.get("user/repos")
     JSON.parse(response.body, symbolize_names: true)

--- a/app/views/invite/new.html.erb
+++ b/app/views/invite/new.html.erb
@@ -1,0 +1,10 @@
+<h1 align= "center">Invite Github User</h1>
+<center>
+  <%= form_tag "/invite", method: :post do %>
+
+    <%= label_tag :github_handle %>
+    <%= text_field_tag :github_handle %>
+
+    <%= submit_tag 'Send Invite' %>
+  <% end %>
+</center>

--- a/app/views/user_mailer/invite_email.html.erb
+++ b/app/views/user_mailer/invite_email.html.erb
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta content='text/html; charset=UTF-8' http-equiv='Content-Type' />
+  </head>
+  <body>
+    <h1>Hello <%= @user[:name] %>,</h1>
+    <p>
+      <%= @current_user_name %> has invited you to join
+      Turing Video Tutorials. You can create an account <%= link_to 'here', signup_url %>.
+    </p>
+  </body>
+</html>

--- a/app/views/user_mailer/invite_email.txt.erb
+++ b/app/views/user_mailer/invite_email.txt.erb
@@ -1,0 +1,4 @@
+Hello <%= @user[:name] %>,
+
+<%= @current_user_name %> has invited you to join
+Turing Video Tutorials. You can create an account <%= link_to 'here', signup_url %>.

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -9,6 +9,8 @@
     <li> <%= current_user.status%> </li>
   </ul>
 
+  <p><%= link_to "Invite a Github friend! ", '/invite' %></p>
+
   <% if current_user.github_token %>
     <h4>Github Repo's</h4>
     <section id="Github">
@@ -55,6 +57,7 @@
   <% else %>
     <%= button_to 'Connect to Github', github_login_path %>
   <% end %>
+
 
   <h1>Bookmarked Segments</h1>
   <section id="Bookmarks">

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -9,9 +9,10 @@
     <li> <%= current_user.status%> </li>
   </ul>
 
-  <p><%= link_to "Invite a Github friend! ", '/invite' %></p>
 
   <% if current_user.github_token %>
+    <p><%= link_to "Invite a Github friend! ", '/invite' %></p>
+    
     <h4>Github Repo's</h4>
     <section id="Github">
       <% user_info.github_repos.each_with_index do |repo, index| %>
@@ -26,7 +27,7 @@
       <% user_info.github_followers.each_with_index do |follower, index| %>
       <section id="follower-<%= index %>">
         <p><%= link_to follower.login, follower.html_url %></p>
-        <% if follower.id != nil && user_info.friend_check?(user.id) %>
+        <% if follower.id != nil && user_info.friend_check?(follower.id) %>
           <p><%= button_to "Add Friend", "/friendships/#{follower.id}", method: :post %></p>
         <% end %>
       </section>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,9 @@
 Rails.application.routes.draw do
 
   get '/activate/:id', to: 'activate#show', as: 'activate'
+  get '/invite', to: "invite#new"
+  post '/invite', to: "invite#create"
+  
   get 'auth/github', as: 'github_login'
   get '/auth/:github/callback', to: "github#create"
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,9 +1,12 @@
 Rails.application.routes.draw do
 
   get '/activate/:id', to: 'activate#show', as: 'activate'
+
   get '/invite', to: "invite#new"
   post '/invite', to: "invite#create"
-  
+
+  get '/signup', to: "users#new"
+
   get 'auth/github', as: 'github_login'
   get '/auth/:github/callback', to: "github#create"
 

--- a/spec/features/user/can_send_email_invite_spec.rb
+++ b/spec/features/user/can_send_email_invite_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 describe 'As a logged in user', :vcr do
 
   it 'I see a link to invite a Github user on my dashboard' do
-    user = create(:user)
+    user = create(:user, github_token: ENV['Github_access_token'])
 
     allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
 
@@ -13,7 +13,7 @@ describe 'As a logged in user', :vcr do
 
     expect(current_path).to eq('/invite')
 
-    fill_in "Github handle", with: "tyladevon"
+    fill_in "Github handle", with: "not-zorro"
 
     click_on "Send Invite"
 
@@ -23,7 +23,7 @@ describe 'As a logged in user', :vcr do
   end
 
   it "cannot send an invite to a non-Github user" do
-    user = create(:user)
+    user = create(:user, github_token: ENV['Github_access_token'])
 
     allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
 

--- a/spec/features/user/can_send_email_invite_spec.rb
+++ b/spec/features/user/can_send_email_invite_spec.rb
@@ -1,6 +1,7 @@
 require 'rails_helper'
 
-describe 'As a logged in user' do
+describe 'As a logged in user', :vcr do
+
   it 'I see a link to invite a Github user on my dashboard' do
     user = create(:user)
 
@@ -8,10 +9,36 @@ describe 'As a logged in user' do
 
     visit dashboard_path
 
-    click_button 'Send Invite'
+    click_on 'Invite a Github friend!'
 
     expect(current_path).to eq('/invite')
+
+    fill_in "Github handle", with: "tyladevon"
+
+    click_on "Send Invite"
+
+    expect(current_path).to eq('/dashboard')
+
+    expect(page).to have_content("Successfully sent invite!")
   end
 
-  it ''
+  it "cannot send an invite to a non-Github user" do
+    user = create(:user)
+
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+
+    visit dashboard_path
+
+    click_on 'Invite a Github friend!'
+
+    expect(current_path).to eq('/invite')
+
+    fill_in "Github handle", with: "blahblah"
+
+    click_on "Send Invite"
+
+    expect(current_path).to eq('/dashboard')
+
+    expect(page).to have_content("The Github user you selected doesn't have an email address associated with their account.")
+  end
 end


### PR DESCRIPTION
Users who are logged in and connected to Github are able to send an invite to another Github user via their Github username. If email address is unavailable from Github API, site fails gracefully with a flash message informing user. If email address is found, an email is sent to that address with a link to signup.